### PR TITLE
Use context-managed SQLite connections with error logging

### DIFF
--- a/penelopa.py
+++ b/penelopa.py
@@ -3,6 +3,7 @@ import os
 import sqlite3
 import subprocess
 from datetime import UTC, datetime
+import logging
 
 DB_PATH = 'penelopa.db'
 ORIGIN_TEXT = os.path.join('origin', 'molly.md')
@@ -34,26 +35,33 @@ def get_diff(prev_commit: str, current_commit: str) -> str:
 
 
 def init_db(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS changes (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            commit_hash TEXT,
-            repo_hash TEXT,
-            diff TEXT,
-            size INTEGER,
-            created_at TEXT
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS changes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                commit_hash TEXT,
+                repo_hash TEXT,
+                diff TEXT,
+                size INTEGER,
+                created_at TEXT
+            )
+            """
         )
-        """
-    )
-    conn.commit()
+        conn.commit()
+    except Exception:
+        logging.exception("Failed to initialize database")
 
 
 def get_last_commit(conn: sqlite3.Connection) -> str | None:
-    cur = conn.cursor()
-    cur.execute('SELECT commit_hash FROM changes ORDER BY id DESC LIMIT 1')
-    row = cur.fetchone()
-    return row[0] if row else None
+    try:
+        cur = conn.cursor()
+        cur.execute('SELECT commit_hash FROM changes ORDER BY id DESC LIMIT 1')
+        row = cur.fetchone()
+        return row[0] if row else None
+    except Exception:
+        logging.exception("Failed to fetch last commit")
+        return None
 
 
 def log_change(
@@ -63,20 +71,27 @@ def log_change(
     diff: str,
 ) -> None:
     size = len(diff.encode('utf-8'))
-    conn.execute(
-        '''
-        INSERT INTO changes (commit_hash, repo_hash, diff, size, created_at)
-        VALUES (?, ?, ?, ?, ?)
-        ''',
-        (commit_hash, repo_hash, diff, size, datetime.now(UTC).isoformat()),
-    )
-    conn.commit()
+    try:
+        conn.execute(
+            '''
+            INSERT INTO changes (commit_hash, repo_hash, diff, size, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ''',
+            (commit_hash, repo_hash, diff, size, datetime.now(UTC).isoformat()),
+        )
+        conn.commit()
+    except Exception:
+        logging.exception("Failed to log repository change")
 
 
 def total_logged_size(conn: sqlite3.Connection) -> int:
-    cur = conn.cursor()
-    cur.execute('SELECT COALESCE(SUM(size), 0) FROM changes')
-    return cur.fetchone()[0]
+    try:
+        cur = conn.cursor()
+        cur.execute('SELECT COALESCE(SUM(size), 0) FROM changes')
+        return cur.fetchone()[0]
+    except Exception:
+        logging.exception("Failed to compute logged size")
+        return 0
 
 
 def fine_tune() -> None:
@@ -92,22 +107,22 @@ def fine_tune() -> None:
 def main() -> None:
     commit = get_current_commit()
     sha = repo_sha256(commit)
+    try:
+        with sqlite3.connect(DB_PATH) as conn:
+            init_db(conn)
 
-    conn = sqlite3.connect(DB_PATH)
-    init_db(conn)
+            last_commit = get_last_commit(conn)
+            if commit != last_commit:
+                diff = get_diff(last_commit, commit)
+                log_change(conn, commit, sha, diff)
+                print('Repository change detected and logged.')
+            else:
+                print('No repository changes detected.')
 
-    last_commit = get_last_commit(conn)
-    if commit != last_commit:
-        diff = get_diff(last_commit, commit)
-        log_change(conn, commit, sha, diff)
-        print('Repository change detected and logged.')
-    else:
-        print('No repository changes detected.')
-
-    if total_logged_size(conn) > THRESHOLD_BYTES:
-        fine_tune()
-
-    conn.close()
+            if total_logged_size(conn) > THRESHOLD_BYTES:
+                fine_tune()
+    except Exception:
+        logging.exception("Database operation failed")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- replace manual sqlite3 connection handling in molly.py and penelopa.py with context-managed connections
- wrap database operations in try/except and log failures

## Testing
- `pytest -q`
- `ruff check molly.py penelopa.py`


------
https://chatgpt.com/codex/tasks/task_e_689d9eac8508832993a56f69a499dde9