### PR TITLE
Add secure log directory and backup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+logs/*
+!logs/.gitkeep

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -1,0 +1,14 @@
+# Logging and Backup
+
+This project stores runtime logs in the `logs/` directory, which is created
+with permissions `700` so only the owner can access it.
+
+To back up the SQLite database (`lines.db`) and the text log (`lines.txt`), use
+`backup_logs.sh`:
+
+```bash
+./backup_logs.sh /path/to/secure/backup
+```
+
+Schedule this script with `cron` or another task scheduler to run periodically
+and safeguard your data.

--- a/backup_logs.sh
+++ b/backup_logs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./backup_logs.sh /secure/backup
+# Copies lines.db and lines.txt from the logs directory to the specified backup
+# location with a timestamp. Suitable for scheduling via cron.
+
+LOG_DIR="$(dirname "$0")/logs"
+DB_SRC="$LOG_DIR/lines.db"
+TXT_SRC="$LOG_DIR/lines.txt"
+DEST_DIR="${1:-/secure/backup}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+mkdir -p "$DEST_DIR"
+[ -f "$DB_SRC" ] && cp "$DB_SRC" "$DEST_DIR/lines_${TIMESTAMP}.db"
+[ -f "$TXT_SRC" ] && cp "$TXT_SRC" "$DEST_DIR/lines_${TIMESTAMP}.txt"

--- a/molly.py
+++ b/molly.py
@@ -19,8 +19,9 @@ from telegram.ext import (
 )
 
 ORIGIN_TEXT = Path('origin/molly.md')
-LINES_FILE = Path('origin/logs/lines.txt')
-DB_PATH = Path('origin/logs/lines.db')
+LOG_DIR = Path('logs')
+LINES_FILE = LOG_DIR / 'lines.txt'
+DB_PATH = LOG_DIR / 'lines.db'
 
 
 def load_user_lines() -> list[str]:
@@ -32,7 +33,9 @@ def load_user_lines() -> list[str]:
 
 
 def init_db() -> None:
-    """Ensure the SQLite database exists."""
+    """Ensure the log directory and SQLite database exist."""
+    LOG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    LOG_DIR.chmod(0o700)
     conn = sqlite3.connect(DB_PATH)
     conn.execute(
         '''


### PR DESCRIPTION
## Summary
- direct Molly's logs to a dedicated `logs` folder and ensure it is created with restrictive permissions
- provide a `backup_logs.sh` helper to archive `lines.db` and `lines.txt` to a secure destination
- document log storage and backup usage in `LOGGING.md`

## Testing
- `ls -ld logs`
- `flake8` *(fails: many style violations across the project)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9ee9126083298bbde457b97a925a