### PR TITLE
Refactor configuration handling to use argparse

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -7,6 +7,7 @@ import numpy as np
 import time
 import torch
 from model import GPTConfig, GPT
+from configurator import update_config
 
 # -----------------------------------------------------------------------------
 batch_size = 8
@@ -15,7 +16,7 @@ seed = 1337
 device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1', etc.
 dtype = 'bfloat16' # 'float32' or 'bfloat16' or 'float16'
 compile = True # use PyTorch 2.0 to compile the model to be faster
-exec(open('configurator.py').read()) # overrides from command line or config file
+update_config(globals())
 # -----------------------------------------------------------------------------
 
 torch.manual_seed(seed)

--- a/configurator.py
+++ b/configurator.py
@@ -1,47 +1,86 @@
-"""
-Poor Man's Configurator. Probably a terrible idea. Example usage:
-$ python train.py config/override_file.py --batch_size=32
-this will first run config/override_file.py, then override batch_size to 32
+"""Configuration utilities using argparse.
 
-The code in this file will be run as follows from e.g. train.py:
->>> exec(open('configurator.py').read())
-
-So it's not a Python module, it's just shuttling this code away from train.py
-The code in this script then overrides the globals()
-
-I know people are not going to love this, I just really dislike configuration
-complexity and having to prepend config. to every single variable. If someone
-comes up with a better simple Python solution I am all ears.
+This module provides a function :func:`update_config` that updates a dictionary
+of configuration values based on command line arguments and an optional config
+file. The config file can be in `.py` or `.yaml` format and is parsed without
+executing arbitrary code.
 """
 
-import sys
-from ast import literal_eval
+from __future__ import annotations
 
-for arg in sys.argv[1:]:
-    if '=' not in arg:
-        # assume it's the name of a config file
-        assert not arg.startswith('--')
-        config_file = arg
-        print(f"Overriding config with {config_file}:")
-        with open(config_file) as f:
-            print(f.read())
-        exec(open(config_file).read())
-    else:
-        # assume it's a --key=value argument
-        assert arg.startswith('--')
-        key, val = arg.split('=')
-        key = key[2:]
-        if key in globals():
-            try:
-                # attempt to eval it it (e.g. if bool, number, or etc)
-                attempt = literal_eval(val)
-            except (SyntaxError, ValueError):
-                # if that goes wrong, just use the string
-                attempt = val
-            # ensure the types match ok
-            assert type(attempt) == type(globals()[key])
-            # cross fingers
-            print(f"Overriding: {key} = {attempt}")
-            globals()[key] = attempt
-        else:
-            raise ValueError(f"Unknown config key: {key}")
+import argparse
+import ast
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def _str2bool(v: str) -> bool:
+    if v.lower() in {"1", "true", "yes", "y"}:
+        return True
+    if v.lower() in {"0", "false", "no", "n"}:
+        return False
+    raise argparse.ArgumentTypeError("boolean value expected")
+
+
+def _eval_node(node: ast.AST) -> Any:
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.List):
+        return [_eval_node(n) for n in node.elts]
+    if isinstance(node, ast.Tuple):
+        return tuple(_eval_node(n) for n in node.elts)
+    if isinstance(node, ast.Dict):
+        return {_eval_node(k): _eval_node(v) for k, v in zip(node.keys, node.values)}
+    raise ValueError("Unsupported expression in config file")
+
+
+def _read_config_file(path: Path) -> Dict[str, Any]:
+    if path.suffix in {".yaml", ".yml"}:
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    if path.suffix == ".py":
+        with open(path, "r", encoding="utf-8") as f:
+            node = ast.parse(f.read(), filename=str(path))
+        cfg: Dict[str, Any] = {}
+        for stmt in node.body:
+            if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 and isinstance(
+                stmt.targets[0], ast.Name
+            ):
+                cfg[stmt.targets[0].id] = _eval_node(stmt.value)
+        return cfg
+    raise ValueError(f"Unsupported config file: {path}")
+
+
+def update_config(cfg: Dict[str, Any]) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, default=None, help="Path to .py or .yaml config")
+    for key, value in list(cfg.items()):
+        if key.startswith("_"):
+            continue
+        if isinstance(value, bool):
+            parser.add_argument(f"--{key}", type=_str2bool)
+        elif isinstance(value, int):
+            parser.add_argument(f"--{key}", type=int)
+        elif isinstance(value, float):
+            parser.add_argument(f"--{key}", type=float)
+        elif isinstance(value, str):
+            parser.add_argument(f"--{key}", type=str)
+        elif isinstance(value, tuple) and all(isinstance(x, float) for x in value):
+            parser.add_argument(f"--{key}", type=lambda s: tuple(float(x) for x in s.split(',')))
+    args = parser.parse_args()
+
+    file_cfg: Dict[str, Any] = {}
+    if args.config:
+        file_cfg = _read_config_file(Path(args.config))
+
+    for k, v in file_cfg.items():
+        if k not in cfg:
+            raise ValueError(f"Unknown config key: {k}")
+        cfg[k] = v
+
+    for k, v in vars(args).items():
+        if k == "config" or v is None:
+            continue
+        cfg[k] = v

--- a/sample.py
+++ b/sample.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 import torch
 import tiktoken
 from model import GPTConfig, GPT
+from configurator import update_config
 
 # -----------------------------------------------------------------------------
 out_dir = 'out'
@@ -18,7 +19,7 @@ seed = 1337
 device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1', etc.
 dtype = 'bfloat16' # 'float32' or 'bfloat16' or 'float16'
 compile = False # use PyTorch 2.0 to compile the model to be faster
-exec(open('configurator.py').read()) # overrides from command line or config file
+update_config(globals())
 # -----------------------------------------------------------------------------
 
 torch.manual_seed(seed)

--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.distributed import init_process_group, destroy_process_group
 
 from model import GPTConfig, GPT
+from configurator import update_config
 
 # -----------------------------------------------------------------------------
 # default config values designed to train a gpt2 (124M) on OpenWebText
@@ -61,7 +62,7 @@ device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1', etc.
 dtype = 'bfloat16' # 'float32' or 'bfloat16'
 compile = True # use PyTorch 2.0 to compile the model to be faster
 # -----------------------------------------------------------------------------
-exec(open('configurator.py').read()) # overrides from command line or config file
+update_config(globals())
 # -----------------------------------------------------------------------------
 
 # various inits, derived attributes, I/O setup


### PR DESCRIPTION
## Summary
- Replace exec-based configurator with argparse utilities
- Add safe parsing of YAML or Python config files
- Update train, bench, and sample scripts to use the new configurator

## Testing
- `pytest`
- `flake8` *(fails: style issues in train.py)*
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689d9f051bf48329b19520ec01da9eb6