### PR TITLE
Add tests and CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          pip install pytest ruff python-telegram-bot
+      - name: Lint
+        run: ruff .
+      - name: Test
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -1,0 +1,26 @@
+import molly
+
+
+def test_text_chunks_no_word_cut(tmp_path, monkeypatch):
+    text = "one two three four five six seven eight nine ten"
+    file_path = tmp_path / "molly.md"
+    file_path.write_text(text)
+    monkeypatch.setattr(molly, "ORIGIN_TEXT", file_path)
+    monkeypatch.setattr(molly.random, "randint", lambda a, b: 10)
+    chunks = list(molly.text_chunks())
+    assert " ".join(chunks) == text
+    max_word = max(len(w) for w in text.split())
+    for chunk in chunks:
+        assert len(chunk) <= 10 + max_word
+
+
+def test_prepare_lines(monkeypatch):
+    monkeypatch.setattr(molly.random, "randint", lambda a, b: 2)
+    text = "Hello world! How are you? I'm fine."
+    lines = molly.prepare_lines(text)
+    assert len(lines) == 2
+    assert all(lines)
+
+
+def test_prepare_lines_empty():
+    assert molly.prepare_lines("!!!") == []

--- a/tests/test_penelopa.py
+++ b/tests/test_penelopa.py
@@ -1,0 +1,17 @@
+import sqlite3
+
+import penelopa
+
+
+def test_log_change_inserts_row():
+    conn = sqlite3.connect(":memory:")
+    penelopa.init_db(conn)
+    penelopa.log_change(conn, "abc", "sha", "diff")
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT commit_hash, repo_hash, diff, size FROM changes"
+    )
+    row = cur.fetchone()
+    assert row == ("abc", "sha", "diff", len("diff".encode("utf-8")))
+    assert cur.fetchone() is None
+    conn.close()


### PR DESCRIPTION
## Summary
- add unit tests for text chunking, line preparation, and change logging
- configure pytest and ruff via `pyproject.toml`
- set up GitHub Actions to run lint and tests

## Testing
- `ruff check .` *(fails: Found 86 errors)*
- `ruff check tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9f4e7d008329958d594f885efdd1