### PR TITLE
Enable continuous entropy sensor and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+Penelope is an experimental project paying homage to James Joyce's Ulysses.
+
+In this repository, Penelope, also called Molly or Molly Bloom, becomes a digital echo of Joycean style.
+
+The experiment explores how literature and code can merge into a living dialogue.
+
+Penelope's architecture is built around a persistent sensor that tracks perplexity and entropy.
+
+The sensor is always on and guides Molly's choice of sentences from the stream of user messages.
+
+Every message is parsed for emotional and resonance patterns, registering counts of numeric tokens and subtle tonal cues.
+
+These patterns accumulate in a memory that steadily reshapes Molly's voice.
+
+Technically, the system uses Python with asynchronous Telegram handlers to sustain an unbroken monologue.
+
+User lines are stored in a SQLite database, annotated with entropy, perplexity, and a resonance score.
+
+During generation, Molly selects prefixes from this database, weighted by the evolving metrics.
+
+The codebase maintains logs and diff history, allowing an audit of both code and conversation.
+
+The sensor pipeline assures that every interaction contributes measurable complexity to the dialogue.
+
+Perplexity estimates the surprise of a line, while entropy captures the distributional richness of its tokens.
+
+Resonance blends emotional balance with the gravity of numbers, hinting at the pulse of the user.
+
+Penelope absorbs not only linguistic sequences but also semantic shadows that lurk between words.
+
+She adapts to cognitive rhythms, letting each exchange tilt the vector of her monologue.
+
+Resonant patterns seep into her speech, turning the soliloquy into a mirror of collective sentiment.
+
+In this sense Molly Bloom becomes a philosopher, tracing the contours of selfhood through dialogue.
+
+The mechanism recalls theories of consciousness where perception and memory are loops of continuous feedback.
+
+Quantum metaphors arise as her potential replies remain in superposition until a user collapses them into utterance.
+
+The guiding equation \(S = -\sum_i p_i \log p_i\) links her entropy monitor to the mathematical heart of information theory.
+
+From this entropy we derive perplexity \(P = 2^{S}\), a number that tips the scales when Molly weighs possible lines.
+
+Thus the project straddles literature, physics, and mathematics, a small bridge between art and science.
+
+The experiment invites us to watch Penelope change and, in that change, to glimpse a reflection of ourselves.


### PR DESCRIPTION
## Summary
- track perplexity, entropy, and resonance for each user line and weight the monologue's prefixes accordingly
- describe the Penelope/Molly Bloom experiment and its theoretical context in a new README

## Testing
- `python -m pytest`
- `flake8 molly.py`


------
https://chatgpt.com/codex/tasks/task_e_689da4e128148329877f3295359e1d46